### PR TITLE
Add link to view all posts in home page

### DIFF
--- a/cookies-policy.html
+++ b/cookies-policy.html
@@ -9,7 +9,7 @@ hide_in_menu: hide
 <div class="container clearfix"> 
 
 	<h1>COOKIE POLICY</h1>
-	<p><b>Last updated September 20, 2020</b></p>
+	<p><b>Last updated June 14, 2026</b></p>
 	<p>
 		This Cookie Policy explains how we use cookies and similar technologies to recognize you when you visit our websites at https://www.alfonsoalba.com, ("Websites"). It explains what these technologies are and why we use them, as well as your rights to control our use of them.
 	</p>
@@ -47,11 +47,11 @@ hide_in_menu: hide
 	</h2>
 
 	<p>
-			You have the right to decide whether to accept or reject cookies. You can exercise your cookie rights by setting your preferences in the Cookie Consent Manager. The Cookie Consent Manager allows you to select which categories of cookies you accept or reject. Essential cookies cannot be rejected as they are strictly necessary to provide you with services.
+			You have the right to decide whether to accept or reject cookies. You can exercise your cookie rights by setting your preferences in the CookieYes cookie banner and preferences center. CookieYes allows you to select which categories of cookies you accept or reject. Essential cookies cannot be rejected as they are strictly necessary to provide you with services.
 	</p>
 
 	<p>
-			The Cookie Consent Manager can be found in the notification banner and on our website. If you choose to reject cookies, you may still use our website though your access to some functionality and areas of our website may be restricted. You may also set or amend your web browser controls to accept or refuse cookies. As the means by which you can refuse cookies through your web browser controls vary from browser-to-browser, you should visit your browser's help menu for more information.
+			The CookieYes controls are available through the cookie banner and preferences center on our website. If you choose to reject cookies, you may still use our website though your access to some functionality and areas of our website may be restricted. You may also set or amend your web browser controls to accept or refuse cookies. As the means by which you can refuse cookies through your web browser controls vary from browser-to-browser, you should visit your browser's help menu for more information.
 	</p>
 
 	<p>
@@ -71,9 +71,9 @@ hide_in_menu: hide
 	</p>
 
 	<pre>
-	Name: karo
+	Name: cookieyes-consent (and related CookieYes cookies)
 	Purpose: Store your cookies preferences.
-	Service: Cookie consent
+	Service: CookieYes
 	Provider: .alfonsoalba.com
 	Country: Spain
 	Type: LocalStorage
@@ -198,6 +198,6 @@ hide_in_menu: hide
 		If you have any questions about our use of cookies or other technologies, please email us at alfonso _at_ alfonsoalba.com
 	</p>
 
-	<p>This cookie policy was created using Termly’s Cookie Consent Manager.</p>
+	<p>This cookie policy is managed through CookieYes.</p>
 
 </div> <!-- .container.clearfix -->

--- a/index.md
+++ b/index.md
@@ -59,4 +59,9 @@ list_title: Recent from the blog
 	</div>
 </div>
 
+<div class="section mb-0 mt-0 pt-0 text-center">
+    <a href="{% link blog.html %}"> View all posts →</a>
+</div>
+
+
 {%- endif -%}


### PR DESCRIPTION
## Summary
- add a "View all posts" link below recent posts on the home page
- update cookie policy wording to align with CookieYes labels

Closes #45